### PR TITLE
Add @xterm/addon-clipboard for OSC 52 clipboard support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "sshwifty-ui",
       "version": "0.0.0",
       "license": "AGPL-3.0-only",
+      "dependencies": {
+        "@xterm/addon-clipboard": "^0.2.0"
+      },
       "devDependencies": {
         "@azurity/pure-nerd-font": "^3.0.5",
         "@babel/core": "^7.29.0",
@@ -99,7 +102,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2685,7 +2687,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3074,6 +3075,15 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@xterm/addon-clipboard": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-clipboard/-/addon-clipboard-0.2.0.tgz",
+      "integrity": "sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-base64": "^3.7.5"
+      }
+    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
@@ -3142,7 +3152,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3951,7 +3960,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5452,7 +5460,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5513,7 +5520,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7815,6 +7821,12 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-base64": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9129,7 +9141,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9785,7 +9796,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10200,7 +10210,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11555,7 +11564,6 @@
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
     "test": "npm run generate && npm run testonly"
   },
   "author": "",
-  "license": "AGPL-3.0-only"
+  "license": "AGPL-3.0-only",
+  "dependencies": {
+    "@xterm/addon-clipboard": "^0.2.0"
+  }
 }

--- a/ui/widgets/screen_console.vue
+++ b/ui/widgets/screen_console.vue
@@ -106,6 +106,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { WebglAddon } from "@xterm/addon-webgl";
 import { FitAddon } from "@xterm/addon-fit";
+import { ClipboardAddon } from "@xterm/addon-clipboard";
 import { isNumber } from "../commands/common.js";
 import { consoleScreenKeys } from "./screen_console_keys.js";
 
@@ -250,6 +251,7 @@ class Term {
     this.term.loadAddon(this.fit);
     this.term.loadAddon(new WebLinksAddon());
     this.term.loadAddon(new Unicode11Addon());
+    this.term.loadAddon(new ClipboardAddon());
     try {
       if (webglSupported()) {
         this.term.loadAddon(new WebglAddon());


### PR DESCRIPTION
## Problem

Selecting text in a terminal session and having it land in the system
clipboard does not work (e.g. tmux/zellij `copy_on_select`, or any program
emitting an OSC 52 "set clipboard" sequence). The escape sequence is silently
ignored, so users on web-based access have no working copy-to-clipboard path.

## Root cause

`ui/widgets/screen_console.vue` initializes `@xterm/xterm` with the fit,
web-links, unicode11 and webgl addons, but **xterm.js core does not implement
OSC 52**. That behaviour is provided exclusively by the separate
`@xterm/addon-clipboard` package, which isn't loaded — so OSC 52 sequences are
dropped.

## Change

- Add `@xterm/addon-clipboard` (`^0.2.0`, matching the pinned
  `@xterm/xterm@6.0.0`).
- Load it alongside the existing addons:
  `this.term.loadAddon(new ClipboardAddon())`.

`ClipboardAddon` defaults to a Base64 provider backed by
`navigator.clipboard`, so no extra configuration is required. Three files
change: `package.json`, `package-lock.json`, `ui/widgets/screen_console.vue`
(two lines).

## Testing

- `npm run build` / full Docker image build succeeds; webpack bundles the
  addon.
- Built image runs and serves the UI (HTTP 200).
- End-to-end: with the addon loaded, OSC 52 from an SSH session (zellij
  copy-on-select) now writes to the OS clipboard via the browser, over HTTPS.
  Without it, the sequence is dropped. Verified in Chromium/Edge.

Note: browser clipboard write requires a secure context (HTTPS) and the
site's clipboard permission not blocked — standard `navigator.clipboard`
constraints, unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)