### PR TITLE
Request xterm-256color PTY instead of xterm

### DIFF
--- a/application/commands/ssh.go
+++ b/application/commands/ssh.go
@@ -527,7 +527,7 @@ func (d *sshClient) remote(
 		return
 	}
 
-	err = session.RequestPty("xterm", 80, 40, ssh.TerminalModes{
+	err = session.RequestPty("xterm-256color", 80, 40, ssh.TerminalModes{
 		ssh.ECHO:          1,
 		ssh.TTY_OP_ISPEED: 14400,
 		ssh.TTY_OP_OSPEED: 14400,


### PR DESCRIPTION
## Problem

Programs that use 256-color themes — e.g. Midnight Commander — refuse to
load them over a Sshwifty session:

> Unable to use 'modarin256-defbg-thin' skin with 256 colors support on
> non-256 colors terminal. Default skin has been loaded

## Root cause

`application/commands/ssh.go` requests the SSH PTY as `"xterm"`. The
`xterm` terminfo entry declares only 8 colors, so curses/slang programs
correctly conclude the terminal is not 256-color and fall back.

Sshwifty's frontend is xterm.js, which fully supports 256-color (and
truecolor). The terminal type is simply mislabeled.

## Change

Request the PTY as `xterm-256color` instead of `xterm` (one line). Color
capability is then reported accurately; 256-color-aware programs work as
expected and output is unaffected for everything else.

## Testing

- Build + image run OK.
- Over the session `echo $TERM` reports `xterm-256color`; Midnight
  Commander loads its 256-color skin instead of falling back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)